### PR TITLE
Pinned nan dep to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"main": "./build/Release/kbd.node",
 	"gypfile": true,
 	"dependencies": {
-		"nan": "*"
+		"nan": "1.8.4"
 	},
 	"os" : [ "linux", "darwin" ]
 }


### PR DESCRIPTION
`nan` has made breaking changes, so `kbd` won't compile anymore.

Either merge this or adjust the c++ code to adhere to the `nan` changes. This might help: https://github.com/ErikDubbelboer/node-sleep/commit/bebfd6c19cb8c7055d29682446df99088c54bc06
